### PR TITLE
Add local demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # 3DObject-Tracking-JS-Testing
 Run it on: https://jieguann.github.io/3DObject-Tracking-JS-Testing/Objectron/index.html
 
+## Running the demo locally
+
+From the project root (or the `Objectron/` directory), start a simple HTTP server:
+
+```bash
+python3 -m http.server
+```
+
+Then open [http://localhost:8000/Objectron/index.html](http://localhost:8000/Objectron/index.html) in your browser.
+
 ## Cite
 Objectron
 


### PR DESCRIPTION
## Summary
- describe how to run the demo locally using a simple HTTP server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841f3ebe488832ca3da55f9fd6f884b